### PR TITLE
Change sh to bash

### DIFF
--- a/lvmflexvolumed
+++ b/lvmflexvolumed
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 trap "RUNNING=false" SIGINT SIGTERM
 


### PR DESCRIPTION
Hello, i found interesting bug ;) If you have in hostname letter "n", in sh interpreter you have empty charset:
```
root@kubernetes03:~# sh
# IFS=$'\n' && echo host-$(hostname -s)
host-kuber etes03
#
root@kubernetes03:~# bash
root@kubernetes03:~# IFS=$'\n' && echo host-$(hostname -s)
host-kubernetes03
root@kubernetes03:~#
```

And, when you run systemd unit with /bin/sh you have error:
```
Jan 08 17:36:33 kubernetes03 lvmflexvolumed[60551]: grep: etes03: No such file or directory
```